### PR TITLE
Make regex replacements case insensitive in the original string 

### DIFF
--- a/filter.js
+++ b/filter.js
@@ -125,7 +125,7 @@ module.exports = {
             if( index != -1)
             {
                 keyReplacement = replacement[repPatt.pattern](key, repPatt.word);
-                var regex = new RegExp('\\b'+ key + '\\b', 'g');
+                var regex = new RegExp('\\b'+ key + '\\b', 'gi');
                 origString = origString.replace(regex, keyReplacement);
                 lowerStr = origString.toLowerCase();
             }


### PR DESCRIPTION
This allows profanity in capital letters to be detected properly.